### PR TITLE
  NAS-107897 / 20.10 / nginx: Honor custom HTTP port for redirects

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -287,7 +287,7 @@ http {
 % if general_settings['ui_httpsredirect'] and ssl_configuration:
     server {
     % for ip in ip_list:
-        listen    ${ip}:80;
+        listen    ${ip}:${general_settings['ui_port']};
     % endfor
         server_name localhost;
         return 307 https://$host:${general_settings['ui_httpsport']}$request_uri;


### PR DESCRIPTION
We already honored the custom HTTP listen port, if the HTTP to HTTPS redirect was disabled.